### PR TITLE
Cleanup

### DIFF
--- a/projectile-git-autofetch.el
+++ b/projectile-git-autofetch.el
@@ -40,7 +40,6 @@
   :group 'tools)
 
 (define-minor-mode projectile-git-autofetch-mode
-
   "Fetch git repositories periodically."
   :init-value nil
   :group 'projectile-git-autofetch

--- a/projectile-git-autofetch.el
+++ b/projectile-git-autofetch.el
@@ -101,21 +101,24 @@ Selection of projects that should be automatically fetched."
 		   (alert git-output
 			  ':title (format "projectile-git-autofetch: %s" (projectile-project-name)))))))))))
 
+(defvar projectile-git-autofetch-timer nil
+  "Timer object for git fetches.")
+
 (defun projectile-git-autofetch-setup ()
   "Set up timers to periodically fetch repositories."
   (interactive)
-  (if (not (and (boundp 'projectile-git-autofetch-timer) (timerp projectile-git-autofetch-timer)))
-      (defvar projectile-git-autofetch-timer
-	(run-with-timer
-	 projectile-git-autofetch-initial-delay
-	 projectile-git-autofetch-interval
-	 'projectile-git-autofetch-run))))
+  (unless (timerp projectile-git-autofetch-timer)
+    (setq projectile-git-autofetch-timer
+	  (run-with-timer
+	   projectile-git-autofetch-initial-delay
+	   projectile-git-autofetch-interval
+	   'projectile-git-autofetch-run))))
 
 (defun projectile-git-autofetch-stop ()
   "Stop auto fetch timers."
   (interactive)
   (cancel-timer projectile-git-autofetch-timer)
-  (makunbound 'projectile-git-autofetch-timer))
+  (setq projectile-git-autofetch-timer nil))
 
 (provide 'projectile-git-autofetch)
 ;;; projectile-git-autofetch.el ends here

--- a/projectile-git-autofetch.el
+++ b/projectile-git-autofetch.el
@@ -1,4 +1,4 @@
-;;; projectile-git-autofetch.el --- automatically fetch git repositories
+;;; projectile-git-autofetch.el --- automatically fetch git repositories  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016  Andreas Müller
 

--- a/projectile-git-autofetch.el
+++ b/projectile-git-autofetch.el
@@ -92,7 +92,9 @@ Selection of projects that should be automatically fetched."
     (dolist (project projects)
       (let ((default-directory project))
 	(when (and (file-directory-p ".git")
-		   (> (length (shell-command-to-string "git config --get remote.origin.url")) 0))
+		   (car (ignore-errors
+			  (process-lines "git" "config" "--get"
+					 "remote.origin.url"))))
 	  (async-start
 	   (lambda () (shell-command-to-string "git fetch"))
 	   (lambda (git-output)

--- a/projectile-git-autofetch.el
+++ b/projectile-git-autofetch.el
@@ -81,16 +81,14 @@ Selection of projects that should be automatically fetched."
 
 (defun projectile-git-autofetch-run ()
   "Fetch all repositories and notify user."
-  (let ((projects))
-    (cond
-     ((eq projectile-git-autofetch-projects 'current)
-      (setq projects (list (projectile-project-root))))
-     ((eq projectile-git-autofetch-projects 'open)
-      (setq projects (projectile-open-projects)))
-     ((eq projectile-git-autofetch-projects 'all)
-      (setq projects projectile-known-projects))
-     (t
-      (setq projects '())))
+  (let ((projects (cond
+		   ((eq projectile-git-autofetch-projects 'current)
+		    (list (projectile-project-root)))
+		   ((eq projectile-git-autofetch-projects 'open)
+		    (projectile-open-projects))
+		   ((eq projectile-git-autofetch-projects 'all)
+		    projectile-known-projects)
+		   (t nil))))
     (dolist (project projects)
       (let ((default-directory project))
 	(if (and (file-directory-p ".git")

--- a/projectile-git-autofetch.el
+++ b/projectile-git-autofetch.el
@@ -91,15 +91,15 @@ Selection of projects that should be automatically fetched."
 		   (t nil))))
     (dolist (project projects)
       (let ((default-directory project))
-	(if (and (file-directory-p ".git")
-		 (> (length (shell-command-to-string "git config --get remote.origin.url")) 0))
-	    (async-start
-	     (lambda () (shell-command-to-string "git fetch"))
-	     (lambda (git-output)
-	       (if (and (> (length git-output) 0)
+	(when (and (file-directory-p ".git")
+		   (> (length (shell-command-to-string "git config --get remote.origin.url")) 0))
+	  (async-start
+	   (lambda () (shell-command-to-string "git fetch"))
+	   (lambda (git-output)
+	     (when (and (> (length git-output) 0)
 			projectile-git-autofetch-notify)
-		   (alert git-output
-			  ':title (format "projectile-git-autofetch: %s" (projectile-project-name)))))))))))
+	       (alert git-output
+		      ':title (format "projectile-git-autofetch: %s" (projectile-project-name)))))))))))
 
 (defvar projectile-git-autofetch-timer nil
   "Timer object for git fetches.")


### PR DESCRIPTION
* Inline cond to avoid repeated setq
* Define the timer variable on top-level instead of repeatedly binding and unbinding it.  
* Enable lexical binding
* Favour when over single-branch ifs
* Use Emacs' built-in facilities for async processes to drop the async.el dependency
* Do not use shell commands, and spawn processes directly instead